### PR TITLE
Fix the height and width arguments in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ the algorithm to use by setting the command line argument '--genAlgorithm'.
 The maze is displayed to the terminal in simple ascii art.
 
 The height and width of the maze can be set with command line arguments 
-'--height=<height>' and '--width=<width>'
+'--height=<heightVal>' and '--width=<widthVal>'
 
 '--genAlgorithm=0' will use the recursive backtracking algorithm.
 '--genAlgorithm=1' will use the modified Prim algorithm.
@@ -20,4 +20,4 @@ Compiling this program requires a working Chapel compiler. See
 http://chapel.cray.com to download the Chapel compiler and for instructions
 for using it.  Once you have a working Chapel compiler this program can be
 built with: "cd src; make maze".  It can be built and executed with:
-"cd src; make HEIGHT=<height> WIDTH=<width> ALGORITHM=<0|1>".
+"cd src; make HEIGHT=<heightVal> WIDTH=<widthVal> ALGORITHM=<0|1>".


### PR DESCRIPTION
They used <height> and <width>, which didn't display right in the HTML version
since they're keywords in HTML.  Change them to <heightVal> and <widthVal>.
